### PR TITLE
[#13] fix failure

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -72,3 +72,4 @@ yum-repo/rpm/zookeeper_3_2_0-server-3.5.9-3.el7.x86_64.rpm filter=lfs diff=lfs m
 yum-repo/rpm/bigtop-select-3.2.0-1.el7.noarch.rpm filter=lfs diff=lfs merge=lfs -text
 yum-repo/rpm/ambari-agent-2.7.6.0-10.el7.noarch.rpm filter=lfs diff=lfs merge=lfs -text
 yum-repo/rpm/bigtop-ambari-mpack-1.0.0.0-2.el7.noarch.rpm filter=lfs diff=lfs merge=lfs -text
+common/lib/apacheds-2.0.0.AM26.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/Dockerfile.apacheds
+++ b/Dockerfile.apacheds
@@ -8,6 +8,7 @@ RUN yum -y install python3-devel.x86_64 && \
 ENV PATH "$PATH:/root/.local/bin"
 
 COPY common/ansible /root/ansible
+COPY common/lib/apacheds-2.0.0.AM26.tar.gz /opt/
 RUN ansible-playbook /root/ansible/init_apacheds.yml
 
 COPY common/script/apacheds_entrypoint.sh /opt/apacheds_entrypoint.sh

--- a/common/ansible/roles/init/apacheds/tasks/main.yml
+++ b/common/ansible/roles/init/apacheds/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: Install apacheds
   ansible.builtin.shell: |
     set -o pipefail
-    curl https://dlcdn.apache.org//directory/apacheds/dist/{{ APACHEDS_VERSION }}/apacheds-{{ APACHEDS_VERSION }}.tar.gz | tar -xvz -C /opt && \
+    tar -xvzf /opt/apacheds-2.0.0.AM26.tar.gz -C /opt && \
     ln -s /opt/apacheds-{{ APACHEDS_VERSION }} /opt/apacheds
   changed_when: true
 - name: Start apacheds

--- a/common/ansible/roles/post/ambari-server/tasks/setup_for_mysql.yml
+++ b/common/ansible/roles/post/ambari-server/tasks/setup_for_mysql.yml
@@ -1,12 +1,9 @@
 ---
-- name: Import gpg key for mysql
-  ansible.builtin.rpm_key:
-    state: present
-    key: https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
 - name: Install mysql-community-client
   ansible.builtin.yum:
     name:
       - mysql-community-client
+    disable_gpg_check: true
 - name: Create link to mysql 8.x connector java
   ansible.builtin.file:
     # mysql connector 8 은 5.6, 5.7 접속이 가능하다. https://www.lesstif.com/dbms/mysql-jdbc-driver-14090356.html

--- a/common/lib/apacheds-2.0.0.AM26.tar.gz
+++ b/common/lib/apacheds-2.0.0.AM26.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d164bd3af8dd7ebc161508dcaadb288a8610c1bb3ca43e7bc71917e9991d533
+size 14490854


### PR DESCRIPTION
- cannot download 2.0.0.AM26 from dlcdn.apache.org anymore
- disable gpgcheck for mysql